### PR TITLE
Restart federation link in the node that hosts it

### DIFF
--- a/priv/www/js/federation.js
+++ b/priv/www/js/federation.js
@@ -30,7 +30,7 @@ dispatcher_add(function(sammy) {
             return false;
     });
     sammy.del("#/restart-link", function(){
-        if(sync_delete(this, '/federation-links/vhost/:vhost/:id/restart')){
+        if(sync_delete(this, '/federation-links/vhost/:vhost/:id/:node/restart')){
             update();
         }
     });

--- a/priv/www/js/tmpl/federation.ejs
+++ b/priv/www/js/tmpl/federation.ejs
@@ -84,6 +84,7 @@
     <td>
         <form action="#/restart-link" method="delete" class="confirm">
         <input type="hidden" name="id" value="<%= link.id %>"/>
+        <input type="hidden" name="node" value="<%= link.node %>"/>
         <input type="hidden" name="vhost" value="<%= link.vhost %>"/>
         <input type="submit" value="Restart"/>
         </form>

--- a/test/federation_mgmt_SUITE.erl
+++ b/test/federation_mgmt_SUITE.erl
@@ -167,7 +167,8 @@ wait_until(Fun, N) ->
 
 restart_uri(Link) ->
     "/federation-links/vhost/%2f/" ++
-        binary_to_list(proplists:get_value(id, Link)) ++ "/restart".
+        binary_to_list(proplists:get_value(id, Link)) ++ "/" ++
+        binary_to_list(proplists:get_value(node, Link)) ++ "/restart".
 
 %% -------------------------------------------------------------------
 %% Helpers from rabbitmq_management tests


### PR DESCRIPTION
Extends the HTTP API to include the node name, which is needed to do a rpc to the node that hosts the link. 