### PR TITLE
Use prefix for refresh link name

### DIFF
--- a/priv/www/js/federation.js
+++ b/priv/www/js/federation.js
@@ -29,7 +29,7 @@ dispatcher_add(function(sammy) {
                 go_to('#/federation-upstreams');
             return false;
     });
-    sammy.del("#/restart-link", function(){
+    sammy.del("#/federation-restart-link", function(){
         if(sync_delete(this, '/federation-links/vhost/:vhost/:id/:node/restart')){
             update();
         }

--- a/priv/www/js/tmpl/federation.ejs
+++ b/priv/www/js/tmpl/federation.ejs
@@ -84,7 +84,7 @@
     <td><%= link.id %></td>
     <td><%= link.consumer_tag %></td>
     <td>
-        <form action="#/restart-link" method="delete" class="confirm">
+        <form action="#/federation-restart-link" method="delete" class="confirm">
         <input type="hidden" name="id" value="<%= link.id %>"/>
         <input type="hidden" name="node" value="<%= link.node %>"/>
         <input type="hidden" name="vhost" value="<%= link.vhost %>"/>


### PR DESCRIPTION
To avoid conflict with another link.

References rabbitmq/rabbitmq-shovel-management#35